### PR TITLE
Catch crashes, instead of flagging `CRASH`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # pull request on our GitHub repository:
 #     https://github.com/kaczmarj/neurodocker
 #
-# Timestamp: 2018-05-06 18:33:27
+# Timestamp: 2018-05-07 20:43:57
 
 FROM neurodebian:stretch-non-free
 
@@ -120,7 +120,7 @@ RUN conda create -y -q --name neuro python=3.6 \
       && pip install -q --no-cache-dir https://github.com/nipy/nipype/tarball/master \
                                        https://github.com/INCF/pybids/tarball/master \
                                        nilearn \
-                                       datalad_neuroimaging \
+                                       datalad[full] \
                                        nipy \
                                        duecredit" \
     && sync \
@@ -218,7 +218,7 @@ RUN echo '{ \
     \n      { \
     \n        "miniconda_version": "4.3.31", \
     \n        "conda_install": "python=3.6 pytest jupyter jupyterlab jupyter_contrib_nbextensions traits pandas matplotlib scikit-learn scikit-image seaborn nbformat nb_conda", \
-    \n        "pip_install": "https://github.com/nipy/nipype/tarball/master https://github.com/INCF/pybids/tarball/master nilearn datalad_neuroimaging nipy duecredit", \
+    \n        "pip_install": "https://github.com/nipy/nipype/tarball/master https://github.com/INCF/pybids/tarball/master nilearn datalad[full] nipy duecredit", \
     \n        "env_name": "neuro", \
     \n        "activate": true \
     \n      } \
@@ -289,6 +289,6 @@ RUN echo '{ \
     \n      ] \
     \n    ] \
     \n  ], \
-    \n  "generation_timestamp": "2018-05-06 18:33:27", \
+    \n  "generation_timestamp": "2018-05-07 20:43:57", \
     \n  "neurodocker_version": "0.3.2" \
     \n}' > /neurodocker/neurodocker_specs.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # pull request on our GitHub repository:
 #     https://github.com/kaczmarj/neurodocker
 #
-# Timestamp: 2018-04-23 18:54:53
+# Timestamp: 2018-05-06 18:33:27
 
 FROM neurodebian:stretch-non-free
 
@@ -120,7 +120,7 @@ RUN conda create -y -q --name neuro python=3.6 \
       && pip install -q --no-cache-dir https://github.com/nipy/nipype/tarball/master \
                                        https://github.com/INCF/pybids/tarball/master \
                                        nilearn \
-                                       datalad[full] \
+                                       datalad_neuroimaging \
                                        nipy \
                                        duecredit" \
     && sync \
@@ -143,7 +143,7 @@ RUN mkdir /output && chmod 777 /output && chmod a+s /output
 USER neuro
 
 # User-defined BASH instruction
-RUN bash -c "source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*"
+RUN bash -c "source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad update -r && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*"
 
 # User-defined BASH instruction
 RUN bash -c "curl -L https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9 -o /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && tar xf /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz -C /data/ds000114/derivatives/fmriprep/. && rm /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && find /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c -type f -not -name ?mm_T1.nii.gz -not -name ?mm_brainmask.nii.gz -not -name ?mm_tpm*.nii.gz -delete"
@@ -218,7 +218,7 @@ RUN echo '{ \
     \n      { \
     \n        "miniconda_version": "4.3.31", \
     \n        "conda_install": "python=3.6 pytest jupyter jupyterlab jupyter_contrib_nbextensions traits pandas matplotlib scikit-learn scikit-image seaborn nbformat nb_conda", \
-    \n        "pip_install": "https://github.com/nipy/nipype/tarball/master https://github.com/INCF/pybids/tarball/master nilearn datalad[full] nipy duecredit", \
+    \n        "pip_install": "https://github.com/nipy/nipype/tarball/master https://github.com/INCF/pybids/tarball/master nilearn datalad_neuroimaging nipy duecredit", \
     \n        "env_name": "neuro", \
     \n        "activate": true \
     \n      } \
@@ -249,7 +249,7 @@ RUN echo '{ \
     \n    ], \
     \n    [ \
     \n      "run_bash", \
-    \n      "source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*" \
+    \n      "source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad update -r && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*" \
     \n    ], \
     \n    [ \
     \n      "run_bash", \
@@ -289,6 +289,6 @@ RUN echo '{ \
     \n      ] \
     \n    ] \
     \n  ], \
-    \n  "generation_timestamp": "2018-04-23 18:54:53", \
+    \n  "generation_timestamp": "2018-05-06 18:33:27", \
     \n  "neurodocker_version": "0.3.2" \
     \n}' > /neurodocker/neurodocker_specs.json

--- a/create_dockerfile.sh
+++ b/create_dockerfile.sh
@@ -12,7 +12,7 @@ docker run --rm kaczmarj/neurodocker:v0.3.2 generate -b neurodebian:stretch-non-
                  traits pandas matplotlib scikit-learn scikit-image seaborn nbformat nb_conda" \
   pip_install="https://github.com/nipy/nipype/tarball/master
                https://github.com/INCF/pybids/tarball/master
-               nilearn datalad_neuroimaging nipy duecredit" \
+               nilearn datalad[full] nipy duecredit" \
   env_name="neuro" \
   activate=True \
 --run-bash "source activate neuro && jupyter nbextension enable exercise2/main && jupyter nbextension enable spellchecker/main" \

--- a/create_dockerfile.sh
+++ b/create_dockerfile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker run --rm kaczmarj/neurodocker:master generate -b neurodebian:stretch-non-free -p apt \
+docker run --rm kaczmarj/neurodocker:v0.3.2 generate -b neurodebian:stretch-non-free -p apt \
 --install convert3d ants fsl gcc g++ graphviz tree \
           git-annex-standalone vim emacs-nox nano less ncdu \
           tig git-annex-remote-rclone octave \
@@ -12,7 +12,7 @@ docker run --rm kaczmarj/neurodocker:master generate -b neurodebian:stretch-non-
                  traits pandas matplotlib scikit-learn scikit-image seaborn nbformat nb_conda" \
   pip_install="https://github.com/nipy/nipype/tarball/master
                https://github.com/INCF/pybids/tarball/master
-               nilearn datalad[full] nipy duecredit" \
+               nilearn datalad_neuroimaging nipy duecredit" \
   env_name="neuro" \
   activate=True \
 --run-bash "source activate neuro && jupyter nbextension enable exercise2/main && jupyter nbextension enable spellchecker/main" \
@@ -21,7 +21,7 @@ docker run --rm kaczmarj/neurodocker:master generate -b neurodebian:stretch-non-
 --run 'mkdir /data && chmod 777 /data && chmod a+s /data' \
 --run 'mkdir /output && chmod 777 /output && chmod a+s /output' \
 --user=neuro \
---run-bash 'source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*' \
+--run-bash 'source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad update -r && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*' \
 --run-bash 'curl -L https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9 -o /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && tar xf /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz -C /data/ds000114/derivatives/fmriprep/. && rm /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && find /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c -type f -not -name ?mm_T1.nii.gz -not -name ?mm_brainmask.nii.gz -not -name ?mm_tpm*.nii.gz -delete' \
 --copy . "/home/neuro/nipype_tutorial" \
 --user=root \

--- a/notebooks/advanced_create_interfaces.ipynb
+++ b/notebooks/advanced_create_interfaces.ipynb
@@ -45,7 +45,7 @@
     "      <td style=\"text-align:left\">Do not have inputs/outputs, but expose them from the interfaces wrapped inside</td>\n",
     "    </tr>\n",
     "    <tr>\n",
-    "      <td style=\"text-align:left\">Do not cache results (unless you use [interface caching](http://nipype.readthedocs.io/en/latest/users/caching_tutorial.html))</td>\n",
+    "      <td style=\"text-align:left\">Do not cache results (unless you use [interface caching](advanced_interfaces_caching.ipynb))</td>\n",
     "      <td style=\"text-align:left\">Cache results</td>\n",
     "    </tr>\n",
     "    <tr>\n",
@@ -383,7 +383,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TransformInfo().cmdline  # This will CRASH"
+    "try:\n",
+    "    TransformInfo().cmdline\n",
+    "\n",
+    "except(ValueError) as err:\n",
+    "    print('It crashed with...')\n",
+    "    print(\"ValueError:\", err)\n",
+    "else:\n",
+    "    raise"
    ]
   },
   {
@@ -399,7 +406,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_info_interface.inputs.in_file = 'idontexist.tfm'  # This will CRASH, too"
+    "try:\n",
+    "    my_info_interface.inputs.in_file = 'idontexist.tfm'\n",
+    "\n",
+    "except(Exception) as err:\n",
+    "    print('It crashed with...')\n",
+    "    print(\"TraitError:\", err)\n",
+    "else:\n",
+    "    raise"
    ]
   },
   {
@@ -928,9 +942,23 @@
    "source": [
     "will_fail_at_run = TranslateImage(\n",
     "    in_file='/data/ds000114/sub-01/ses-test/anat/sub-01_ses-test_T1w.nii.gz',\n",
-    "    out_file='translated.nii.gz')\n",
+    "    out_file='translated.nii.gz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    result = will_fail_at_run.run()\n",
     "\n",
-    "result = will_fail_at_run.run()  # This will CRASH"
+    "except(NotImplementedError) as err:\n",
+    "    print('It crashed with...')\n",
+    "    print(\"NotImplementedError:\", err)\n",
+    "else:\n",
+    "    raise"
    ]
   },
   {
@@ -978,9 +1006,23 @@
    "source": [
     "half_works = TranslateImage(\n",
     "    in_file='/data/ds000114/sub-01/ses-test/anat/sub-01_ses-test_T1w.nii.gz',\n",
-    "    out_file='translated_nipype.nii.gz')\n",
+    "    out_file='translated_nipype.nii.gz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    result = half_works.run()\n",
     "\n",
-    "result = half_works.run()  # This will CRASH, too"
+    "except(NotImplementedError) as err:\n",
+    "    print('It crashed with...')\n",
+    "    print(\"NotImplementedError:\", err)\n",
+    "else:\n",
+    "    raise"
    ]
   },
   {

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -30,7 +30,7 @@ def _notebook_run(path):
             ep.preprocess(nb, {'metadata': {'path': this_file_directory}})
 
         except CellExecutionError as e:
-            if "TAB" in e.traceback or "CRASH" in e.traceback:
+            if "TAB" in e.traceback:
                 print(str(e.traceback).split("\n")[-2])
             else:
                 raise e

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -85,9 +85,9 @@ def reduce_notebook_load(path):
 Dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "notebooks")
 
 @pytest.mark.parametrize("notebook",
-                         glob(os.path.join(Dir_path, "introduction_*.ipynb")) +
-                         glob(os.path.join(Dir_path, "basic*.ipynb")) +
-                         glob(os.path.join(Dir_path, "advanced*.ipynb")) +
+                         sorted(glob(os.path.join(Dir_path, "introduction_*.ipynb"))) +
+                         sorted(glob(os.path.join(Dir_path, "basic*.ipynb"))) +
+                         sorted(glob(os.path.join(Dir_path, "advanced*.ipynb"))) +
                          [os.path.join(Dir_path, "example_preprocessing.ipynb"),
                           os.path.join(Dir_path, "example_1stlevel.ipynb"),
                           os.path.join(Dir_path, "example_normalize.ipynb"),


### PR DESCRIPTION
As discussed in https://github.com/miykael/nipype_tutorial/pull/72, we currently caught some notebook crashes on circleci, with the keyword `CRASH`.

The problem with catching crashes like this is that the notebook after the crash will not be evaluated anymore.

Therefor, this PR takes care of this by catching the errors with `try` and `except`.