### PR TITLE
Correct jupyter notebook ip issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # pull request on our GitHub repository:
 #     https://github.com/kaczmarj/neurodocker
 #
-# Timestamp: 2018-05-14 11:52:36
+# Timestamp: 2018-05-16 08:08:30
 
 FROM neurodebian:stretch-non-free
 
@@ -126,42 +126,42 @@ RUN conda create -y -q --name neuro python=3.6 \
     && sync \
     && sed -i '$isource activate neuro' $ND_ENTRYPOINT
 
-# User-defined BASH instruction
-RUN bash -c "source activate neuro && jupyter nbextension enable exercise2/main && jupyter nbextension enable spellchecker/main"
-
-# User-defined BASH instruction
-RUN bash -c "mkdir -p ~/.jupyter && echo c.NotebookApp.ip = \\"0.0.0.0\\" > ~/.jupyter/jupyter_notebook_config.py"
+# User-defined instruction
+RUN source activate neuro && jupyter nbextension enable exercise2/main && jupyter nbextension enable spellchecker/main
 
 USER root
 
-# User-defined BASH instruction
-RUN bash -c "mkdir /data && chmod 777 /data && chmod a+s /data"
+# User-defined instruction
+RUN mkdir /data && chmod 777 /data && chmod a+s /data
 
-# User-defined BASH instruction
-RUN bash -c "mkdir /output && chmod 777 /output && chmod a+s /output"
+# User-defined instruction
+RUN mkdir /output && chmod 777 /output && chmod a+s /output
 
 USER neuro
 
-# User-defined BASH instruction
-RUN bash -c "source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad update -r && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*"
+# User-defined instruction
+RUN source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad update -r && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*
 
-# User-defined BASH instruction
-RUN bash -c "curl -L https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9 -o /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && tar xf /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz -C /data/ds000114/derivatives/fmriprep/. && rm /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && find /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c -type f -not -name ?mm_T1.nii.gz -not -name ?mm_brainmask.nii.gz -not -name ?mm_tpm*.nii.gz -delete"
+# User-defined instruction
+RUN curl -L https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9 -o /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && tar xf /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz -C /data/ds000114/derivatives/fmriprep/. && rm /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && find /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c -type f -not -name ?mm_T1.nii.gz -not -name ?mm_brainmask.nii.gz -not -name ?mm_tpm*.nii.gz -delete
 
 COPY [".", "/home/neuro/nipype_tutorial"]
 
-# User-defined BASH instruction
-RUN bash -c "printf \"[user]\n\tname = miykael\n\temail = michaelnotter@hotmail.com\n\" > ~/.gitconfig"
+# User-defined instruction
+RUN printf "[user]\n\tname = miykael\n\temail = michaelnotter@hotmail.com\n" > ~/.gitconfig
 
 USER root
 
-# User-defined BASH instruction
-RUN bash -c "chown -R neuro /home/neuro/nipype_tutorial"
+# User-defined instruction
+RUN chown -R neuro /home/neuro/nipype_tutorial
 
-# User-defined BASH instruction
-RUN bash -c "rm -rf /opt/conda/pkgs/*"
+# User-defined instruction
+RUN rm -rf /opt/conda/pkgs/*
 
 USER neuro
+
+# User-defined instruction
+RUN mkdir -p ~/.jupyter && echo c.NotebookApp.ip = \"0.0.0.0\" > ~/.jupyter/jupyter_notebook_config.py
 
 WORKDIR /home/neuro/nipype_tutorial
 
@@ -227,23 +227,19 @@ RUN echo '{ \
     \n      } \
     \n    ], \
     \n    [ \
-    \n      "run_bash", \
+    \n      "run", \
     \n      "source activate neuro && jupyter nbextension enable exercise2/main && jupyter nbextension enable spellchecker/main" \
-    \n    ], \
-    \n    [ \
-    \n      "run_bash", \
-    \n      "mkdir -p ~/.jupyter && echo c.NotebookApp.ip = \\\"0.0.0.0\\\" > ~/.jupyter/jupyter_notebook_config.py" \
     \n    ], \
     \n    [ \
     \n      "user", \
     \n      "root" \
     \n    ], \
     \n    [ \
-    \n      "run_bash", \
+    \n      "run", \
     \n      "mkdir /data && chmod 777 /data && chmod a+s /data" \
     \n    ], \
     \n    [ \
-    \n      "run_bash", \
+    \n      "run", \
     \n      "mkdir /output && chmod 777 /output && chmod a+s /output" \
     \n    ], \
     \n    [ \
@@ -251,11 +247,11 @@ RUN echo '{ \
     \n      "neuro" \
     \n    ], \
     \n    [ \
-    \n      "run_bash", \
+    \n      "run", \
     \n      "source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad update -r && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*" \
     \n    ], \
     \n    [ \
-    \n      "run_bash", \
+    \n      "run", \
     \n      "curl -L https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9 -o /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && tar xf /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz -C /data/ds000114/derivatives/fmriprep/. && rm /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && find /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c -type f -not -name ?mm_T1.nii.gz -not -name ?mm_brainmask.nii.gz -not -name ?mm_tpm*.nii.gz -delete" \
     \n    ], \
     \n    [ \
@@ -266,7 +262,7 @@ RUN echo '{ \
     \n      ] \
     \n    ], \
     \n    [ \
-    \n      "run_bash", \
+    \n      "run", \
     \n      "printf \"[user]\\\n\\tname = miykael\\\n\\temail = michaelnotter@hotmail.com\\\n\" > ~/.gitconfig" \
     \n    ], \
     \n    [ \
@@ -274,16 +270,20 @@ RUN echo '{ \
     \n      "root" \
     \n    ], \
     \n    [ \
-    \n      "run_bash", \
+    \n      "run", \
     \n      "chown -R neuro /home/neuro/nipype_tutorial" \
     \n    ], \
     \n    [ \
-    \n      "run_bash", \
+    \n      "run", \
     \n      "rm -rf /opt/conda/pkgs/*" \
     \n    ], \
     \n    [ \
     \n      "user", \
     \n      "neuro" \
+    \n    ], \
+    \n    [ \
+    \n      "run", \
+    \n      "mkdir -p ~/.jupyter && echo c.NotebookApp.ip = \\\"0.0.0.0\\\" > ~/.jupyter/jupyter_notebook_config.py" \
     \n    ], \
     \n    [ \
     \n      "workdir", \
@@ -296,6 +296,6 @@ RUN echo '{ \
     \n      ] \
     \n    ] \
     \n  ], \
-    \n  "generation_timestamp": "2018-05-14 11:52:36", \
+    \n  "generation_timestamp": "2018-05-16 08:08:30", \
     \n  "neurodocker_version": "0.3.2" \
     \n}' > /neurodocker/neurodocker_specs.json

--- a/create_dockerfile.sh
+++ b/create_dockerfile.sh
@@ -15,20 +15,20 @@ docker run --rm kaczmarj/neurodocker:v0.3.2 generate -b neurodebian:stretch-non-
                nilearn datalad[full] nipy duecredit" \
   env_name="neuro" \
   activate=True \
---run-bash "source activate neuro && jupyter nbextension enable exercise2/main && jupyter nbextension enable spellchecker/main" \
---run-bash 'mkdir -p ~/.jupyter && echo c.NotebookApp.ip = \"0.0.0.0\" > ~/.jupyter/jupyter_notebook_config.py' \
+--run "source activate neuro && jupyter nbextension enable exercise2/main && jupyter nbextension enable spellchecker/main" \
 --user=root \
---run-bash 'mkdir /data && chmod 777 /data && chmod a+s /data' \
---run-bash 'mkdir /output && chmod 777 /output && chmod a+s /output' \
+--run 'mkdir /data && chmod 777 /data && chmod a+s /data' \
+--run 'mkdir /output && chmod 777 /output && chmod a+s /output' \
 --user=neuro \
---run-bash 'source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad update -r && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*' \
---run-bash 'curl -L https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9 -o /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && tar xf /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz -C /data/ds000114/derivatives/fmriprep/. && rm /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && find /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c -type f -not -name ?mm_T1.nii.gz -not -name ?mm_brainmask.nii.gz -not -name ?mm_tpm*.nii.gz -delete' \
+--run 'source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad update -r && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*' \
+--run 'curl -L https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9 -o /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && tar xf /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz -C /data/ds000114/derivatives/fmriprep/. && rm /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && find /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c -type f -not -name ?mm_T1.nii.gz -not -name ?mm_brainmask.nii.gz -not -name ?mm_tpm*.nii.gz -delete' \
 --copy . "/home/neuro/nipype_tutorial" \
---run-bash 'printf "[user]\n\tname = miykael\n\temail = michaelnotter@hotmail.com\n" > ~/.gitconfig' \
+--run 'printf "[user]\n\tname = miykael\n\temail = michaelnotter@hotmail.com\n" > ~/.gitconfig' \
 --user=root \
---run-bash 'chown -R neuro /home/neuro/nipype_tutorial' \
---run-bash 'rm -rf /opt/conda/pkgs/*' \
+--run 'chown -R neuro /home/neuro/nipype_tutorial' \
+--run 'rm -rf /opt/conda/pkgs/*' \
 --user=neuro \
+--run 'mkdir -p ~/.jupyter && echo c.NotebookApp.ip = \"0.0.0.0\" > ~/.jupyter/jupyter_notebook_config.py' \
 --workdir /home/neuro/nipype_tutorial \
 --cmd "jupyter-notebook" \
 --no-check-urls > Dockerfile

--- a/create_dockerfile.sh
+++ b/create_dockerfile.sh
@@ -1,34 +1,36 @@
 #!/bin/bash
 
-docker run --rm kaczmarj/neurodocker:v0.3.2 generate -b neurodebian:stretch-non-free -p apt \
---install convert3d ants fsl gcc g++ graphviz tree \
-          git-annex-standalone vim emacs-nox nano less ncdu \
-          tig git-annex-remote-rclone octave \
---add-to-entrypoint "source /etc/fsl/fsl.sh" \
---spm version=12 matlab_version=R2017a \
---user=neuro \
---miniconda miniconda_version="4.3.31" \
-  conda_install="python=3.6 pytest jupyter jupyterlab jupyter_contrib_nbextensions
-                 traits pandas matplotlib scikit-learn scikit-image seaborn nbformat nb_conda" \
-  pip_install="https://github.com/nipy/nipype/tarball/master
-               https://github.com/INCF/pybids/tarball/master
-               nilearn datalad[full] nipy duecredit" \
-  env_name="neuro" \
-  activate=True \
---run "source activate neuro && jupyter nbextension enable exercise2/main && jupyter nbextension enable spellchecker/main" \
---user=root \
---run 'mkdir /data && chmod 777 /data && chmod a+s /data' \
---run 'mkdir /output && chmod 777 /output && chmod a+s /output' \
---user=neuro \
---run 'source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad update -r && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*' \
---run 'curl -L https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9 -o /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && tar xf /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz -C /data/ds000114/derivatives/fmriprep/. && rm /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && find /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c -type f -not -name ?mm_T1.nii.gz -not -name ?mm_brainmask.nii.gz -not -name ?mm_tpm*.nii.gz -delete' \
---copy . "/home/neuro/nipype_tutorial" \
---run 'printf "[user]\n\tname = miykael\n\temail = michaelnotter@hotmail.com\n" > ~/.gitconfig' \
---user=root \
---run 'chown -R neuro /home/neuro/nipype_tutorial' \
---run 'rm -rf /opt/conda/pkgs/*' \
---user=neuro \
---run 'mkdir -p ~/.jupyter && echo c.NotebookApp.ip = \"0.0.0.0\" > ~/.jupyter/jupyter_notebook_config.py' \
---workdir /home/neuro/nipype_tutorial \
---cmd "jupyter-notebook" \
---no-check-urls > Dockerfile
+docker run --rm kaczmarj/neurodocker:v0.3.2 generate \
+           --base neurodebian:stretch-non-free \
+           --pkg-manager apt \
+           --install convert3d ants fsl gcc g++ graphviz tree \
+                     git-annex-standalone vim emacs-nox nano less ncdu \
+                     tig git-annex-remote-rclone octave \
+           --add-to-entrypoint "source /etc/fsl/fsl.sh" \
+           --spm version=12 matlab_version=R2017a \
+           --user=neuro \
+           --miniconda miniconda_version="4.3.31" \
+             conda_install="python=3.6 pytest jupyter jupyterlab jupyter_contrib_nbextensions
+                            traits pandas matplotlib scikit-learn scikit-image seaborn nbformat nb_conda" \
+             pip_install="https://github.com/nipy/nipype/tarball/master
+                          https://github.com/INCF/pybids/tarball/master
+                          nilearn datalad[full] nipy duecredit" \
+             env_name="neuro" \
+             activate=True \
+           --run "source activate neuro && jupyter nbextension enable exercise2/main && jupyter nbextension enable spellchecker/main" \
+           --user=root \
+           --run 'mkdir /data && chmod 777 /data && chmod a+s /data' \
+           --run 'mkdir /output && chmod 777 /output && chmod a+s /output' \
+           --user=neuro \
+           --run 'source activate neuro && cd /data && datalad install -r ///workshops/nih-2017/ds000114 && cd ds000114 && datalad update -r && datalad get -r sub-01/ses-test/anat sub-01/ses-test/func/*fingerfootlips*' \
+           --run 'curl -L https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9 -o /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && tar xf /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz -C /data/ds000114/derivatives/fmriprep/. && rm /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c.tar.gz && find /data/ds000114/derivatives/fmriprep/mni_icbm152_nlin_asym_09c -type f -not -name ?mm_T1.nii.gz -not -name ?mm_brainmask.nii.gz -not -name ?mm_tpm*.nii.gz -delete' \
+           --copy . "/home/neuro/nipype_tutorial" \
+           --run 'printf "[user]\n\tname = miykael\n\temail = michaelnotter@hotmail.com\n" > ~/.gitconfig' \
+           --user=root \
+           --run 'chown -R neuro /home/neuro/nipype_tutorial' \
+           --run 'rm -rf /opt/conda/pkgs/*' \
+           --user=neuro \
+           --run 'mkdir -p ~/.jupyter && echo c.NotebookApp.ip = \"0.0.0.0\" > ~/.jupyter/jupyter_notebook_config.py' \
+           --workdir /home/neuro/nipype_tutorial \
+           --cmd "jupyter-notebook" \
+           --no-check-urls > Dockerfile


### PR DESCRIPTION
I've broken the current docker image, because I was using `--run-bash` to declare the notebook ip 0.0.0.0, instead of just `--run`. Therefore, `c.NotebookApp.ip` was saved as `0.0.0.0` instead of `"0.0.0.0"`.

This PR takes care of this and makes a stylistic change to `create_dockerfile.sh`, by indenting the lines and moving `-base` and `-pkg-manager` on a new line.