### PR TITLE
FIX: replace pylab by matplotlib import

### DIFF
--- a/notebooks/basic_import_workflows.ipynb
+++ b/notebooks/basic_import_workflows.ipynb
@@ -118,7 +118,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pylab inline\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
     "from IPython.display import Image\n",
     "smoothwf.write_graph(graph2use='colored', format='png', simple_form=True)\n",
     "Image(filename='/output/susan_smooth/graph.png')"

--- a/notebooks/basic_interfaces.ipynb
+++ b/notebooks/basic_interfaces.ipynb
@@ -69,7 +69,8 @@
    "outputs": [],
    "source": [
     "from nilearn.plotting import plot_anat\n",
-    "%pylab inline\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
     "plot_anat('/data/ds000114/sub-01/ses-test/anat/sub-01_ses-test_T1w.nii.gz', title='original',\n",
     "          display_mode='ortho', dim=-1, draw_cross=False, annotate=False);"
    ]

--- a/notebooks/basic_nodes.ipynb
+++ b/notebooks/basic_nodes.ipynb
@@ -198,7 +198,8 @@
    "outputs": [],
    "source": [
     "from nilearn.plotting import plot_anat\n",
-    "%pylab inline\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
     "plot_anat(bet.inputs.in_file, title='BET input', cut_coords=(10,10,10),\n",
     "          display_mode='ortho', dim=-1, draw_cross=False, annotate=False);\n",
     "plot_anat(res.outputs.out_file, title='BET output', cut_coords=(10,10,10),\n",

--- a/notebooks/basic_workflow.ipynb
+++ b/notebooks/basic_workflow.ipynb
@@ -65,8 +65,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "import nibabel as nb\n",
-    "%pylab inline\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
     "# Let's create a short helper function to plot 3D NIfTI images\n",
     "def plot_slice(fname):\n",
@@ -79,8 +80,8 @@
     "    cut = int(data.shape[-1]/2) + 10\n",
     "\n",
     "    # Plot the data\n",
-    "    imshow(np.rot90(data[..., cut]), cmap=\"gray\")\n",
-    "    gca().set_axis_off()"
+    "    plt.imshow(np.rot90(data[..., cut]), cmap=\"gray\")\n",
+    "    plt.gca().set_axis_off()"
    ]
   },
   {

--- a/notebooks/example_preprocessing.ipynb
+++ b/notebooks/example_preprocessing.ipynb
@@ -497,7 +497,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import pylab as plt\n",
+    "import matplotlib.pyplot as plt\n",
     "par = np.loadtxt('/output/datasink/preproc/sub-01/task-fingerfootlips/sub-01_ses-test_task-fingerfootlips_bold.par')\n",
     "fig, axes = plt.subplots(2, 1, figsize=(15, 5))\n",
     "axes[0].set_ylabel('rotation (radians)')\n",

--- a/notebooks/handson_preprocessing.ipynb
+++ b/notebooks/handson_preprocessing.ipynb
@@ -172,9 +172,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pylab as plt\n",
     "import nibabel as nb\n",
     "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
     "plt.plot(nb.load(func_file).get_fdata()[32, 32, 15, :]);"
    ]
   },
@@ -1261,7 +1261,7 @@
    "source": [
     "# Plot the motion paramters\n",
     "import numpy as np\n",
-    "import pylab as plt\n",
+    "import matplotlib.pyplot as plt\n",
     "par = np.loadtxt('/output/work_preproc/_subject_id_07/mcflirt/'\n",
     "                 'asub-07_ses-test_task-fingerfootlips_bold_roi_mcf.nii.gz.par')\n",
     "fig, axes = plt.subplots(2, 1, figsize=(15, 5))\n",


### PR DESCRIPTION
I was pointed to this https://matthiasbussonnier.com/posts/10-No-PyLab-Thanks.html, and therefore replaced all `pylab` imports or `%pylab inline` with the appropriate imports.