### PR TITLE
ENH: run CircleCi in parallel/workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,20 +2,72 @@ version: 2
 jobs:
   build:
     docker:
-      - image: docker:17.10.0-ce-git
+      - image: docker:18.05.0-ce-git
+    steps:
+      - checkout
+  test_1:
+    docker:
+      - image: docker:18.05.0-ce-git
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: docker build
+          name: docker build 1
           no_output_timeout: 60m
           command: |
-            for i in {1..5}; do
-              docker build -t miykael/nipype_tutorial:$CIRCLE_BRANCH . && break || sleep 15
-            done
+            docker build -t miykael/nipype_tutorial:$CIRCLE_BRANCH .
       - run:
-          name: docker run
+          name: run tests 1
           no_output_timeout: 120m
           command: |
-            docker run -it --rm miykael/nipype_tutorial:$CIRCLE_BRANCH python /home/neuro/nipype_tutorial/test_notebooks.py
+            docker run -it --rm miykael/nipype_tutorial:$CIRCLE_BRANCH python /home/neuro/nipype_tutorial/test_notebooks.py 1
+  test_2:
+    docker:
+      - image: docker:18.05.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: docker build 2
+          no_output_timeout: 60m
+          command: |
+            docker build -t miykael/nipype_tutorial:$CIRCLE_BRANCH .
+      - run:
+          name: run tests 2
+          no_output_timeout: 120m
+          command: |
+            docker run -it --rm miykael/nipype_tutorial:$CIRCLE_BRANCH python /home/neuro/nipype_tutorial/test_notebooks.py 2
+  test_3:
+    docker:
+      - image: docker:18.05.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: docker build 3
+          no_output_timeout: 60m
+          command: |
+            docker build -t miykael/nipype_tutorial:$CIRCLE_BRANCH .
+      - run:
+          name: run tests 3
+          no_output_timeout: 120m
+          command: |
+            docker run -it --rm miykael/nipype_tutorial:$CIRCLE_BRANCH python /home/neuro/nipype_tutorial/test_notebooks.py 3
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test_1:
+          requires:
+            - build
+      - test_2:
+          requires:
+            - build
+      - test_3:
+          requires:
+            - build

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 from glob import glob
 
@@ -55,21 +56,41 @@ if __name__ == '__main__':
 
     test_version()
 
-    notebooks = sorted(glob("/home/neuro/nipype_tutorial/notebooks/introduction_*.ipynb")) + \
-                sorted(glob("/home/neuro/nipype_tutorial/notebooks/basic*.ipynb")) + \
-                sorted(glob("/home/neuro/nipype_tutorial/notebooks/advanced*.ipynb"))
+    # Notebooks that should be tested
+    notebooks = []
 
-    for n in ["/home/neuro/nipype_tutorial/notebooks/example_preprocessing.ipynb",
-              "/home/neuro/nipype_tutorial/notebooks/example_1stlevel.ipynb",
-              "/home/neuro/nipype_tutorial/notebooks/example_normalize.ipynb",
-              "/home/neuro/nipype_tutorial/notebooks/example_2ndlevel.ipynb",
-              "/home/neuro/nipype_tutorial/notebooks/handson_preprocessing.ipynb",
-              "/home/neuro/nipype_tutorial/notebooks/handson_analysis.ipynb"]:
+    # Test mode that should be run
+    test_mode = int(sys.argv[1])
 
-        print('Reducing: %s' % n)
-        notebooks.append(reduce_notebook_load(n))
+    # Specifies which tests should be run
+    if test_mode == 1:
+
+        # Test introduction, basic and advanced notebooks
+        notebooks += sorted(glob("/home/neuro/nipype_tutorial/notebooks/introduction*.ipynb"))
+        notebooks += sorted(glob("/home/neuro/nipype_tutorial/notebooks/basic*.ipynb"))
+        notebooks += sorted(glob("/home/neuro/nipype_tutorial/notebooks/advanced*.ipynb"))
+
+    elif test_mode == 2:
+
+        # Test example notebooks
+        for n in ["/home/neuro/nipype_tutorial/notebooks/example_preprocessing.ipynb",
+                  "/home/neuro/nipype_tutorial/notebooks/example_1stlevel.ipynb",
+                  "/home/neuro/nipype_tutorial/notebooks/example_normalize.ipynb",
+                  "/home/neuro/nipype_tutorial/notebooks/example_2ndlevel.ipynb"]:
+
+            print('Reducing: %s' % n)
+            notebooks.append(reduce_notebook_load(n))
+
+    elif test_mode == 3:
+
+        # Test hands-on notebooks
+        for n in ["/home/neuro/nipype_tutorial/notebooks/handson_preprocessing.ipynb",
+                  "/home/neuro/nipype_tutorial/notebooks/handson_analysis.ipynb"]:
+
+            print('Reducing: %s' % n)
+            notebooks.append(reduce_notebook_load(n))
 
     for test in notebooks:
-        t0 = time.time()
-        os.system('pytest --nbval-lax --nbval-cell-timeout 7200 -v -s %s' % test)
-        print("time", time.time() - t0)
+        pytest_cmd = 'pytest --nbval-lax --nbval-cell-timeout 7200 -v -s %s' % test
+        print(pytest_cmd)
+        os.system(pytest_cmd)


### PR DESCRIPTION
This PR allows the tests on CircleCi to run in parallel. It creates one workflow for the `example` notebooks, one for the `hands_on` and one for the rest (`introduction`, `basic` and `advanced`).

I've looked into two different approaches. *First*, the one approach in this PR creates three different branches on CircleCi and builds the docker image on each of them. As can be seen [here](https://circleci.com/gh/miykael/nipype_tutorial/211) (on CircleCi click on `build_and_test` to see the workflow).
*Second*, an alternative is to create the docker image first, save it in a `tmp` folder and load it from there for the three parallel branches. As can be seen [here](https://circleci.com/gh/miykael/nipype_tutorial/206) (click on `test` to see the workflow).

The first one has more redundancy but finishes quicker, as it doesn't need to store and load the docker image.

I prefer to keep the current (first) approach as it finishes within 1.5h, while the second approach takes about 2h. What do you think @djarecka?