### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Nipype Tutorial Notebooks
 
-This is the Nipype Tutorial in Notebooks. There are multiple ways of how you can profit from this tutorial:
+This is the Nipype Tutorial in Jupyter Notebook format. You can access the tutorial in two ways:
 
-1. [Nipype Tutorial Homepage](https://miykael.github.io/nipype_tutorial/): You can find all notebooks used in this tutorial on this homepage.
-2. [Nipype Tutorial Docker Image](https://miykael.github.io/nipype_tutorial/notebooks/introduction_docker.html): Run the notebooks of this tutorial in an interactive docker image and on real example data. The nipype tutorial docker image is the best interactive way to learn Nipype.
+1. [Nipype Tutorial Homepage](https://miykael.github.io/nipype_tutorial/): This website contains a static, read-only version of all the notebooks.
+2. [Nipype Tutorial Docker Image](https://miykael.github.io/nipype_tutorial/notebooks/introduction_docker.html): This guide explains how to use docker to run the notebooks interactively on your own computer. The nipype tutorial docker image is the best interactive way to learn Nipype.
 
 
 # Feedback, Help & Support


### PR DESCRIPTION
Reword the opening section of the README for clarity. It took me a few clicks to realise that the second link is the super-important guide to how to actually run the docker image (this page might profitably be linked in the docker image readme too). Also trying to avoid assuming prior knowledge of exactly what docker is and how the docker image notebook differs from the static website.