### PR TITLE
ENH: add memory estimate to FSL's segmentation node

### DIFF
--- a/notebooks/example_preprocessing.ipynb
+++ b/notebooks/example_preprocessing.ipynb
@@ -197,7 +197,7 @@
     "\n",
     "# FAST - Image Segmentation\n",
     "segmentation = Node(FAST(output_type='NIFTI_GZ'),\n",
-    "                name=\"segmentation\")\n",
+    "                    name=\"segmentation\", mem_gb=4)\n",
     "\n",
     "# Select WM segmentation file from segmentation output\n",
     "def get_wm(files):\n",


### PR DESCRIPTION
Some people have memory issues, using FSL's segmentation via docker container.

I'm not sure if this change will take care of this, but it's anyhow good to add this parameter here.