### PR TITLE
FIX: correct matplotlib warning after nilearn plotting import [skip ci]

### DIFF
--- a/notebooks/basic_import_workflows.ipynb
+++ b/notebooks/basic_import_workflows.ipynb
@@ -118,6 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from nilearn import plotting\n",
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "from IPython.display import Image\n",

--- a/notebooks/example_1stlevel.ipynb
+++ b/notebooks/example_1stlevel.ipynb
@@ -33,6 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from nilearn import plotting\n",
     "%matplotlib inline\n",
     "from os.path import join as opj\n",
     "import json\n",

--- a/notebooks/example_2ndlevel.ipynb
+++ b/notebooks/example_2ndlevel.ipynb
@@ -32,6 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from nilearn import plotting\n",
     "%matplotlib inline\n",
     "from os.path import join as opj\n",
     "from nipype.interfaces.io import SelectFiles, DataSink\n",

--- a/notebooks/example_preprocessing.ipynb
+++ b/notebooks/example_preprocessing.ipynb
@@ -78,6 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from nilearn import plotting\n",
     "%matplotlib inline\n",
     "from os.path import join as opj\n",
     "import os\n",

--- a/notebooks/handson_analysis.ipynb
+++ b/notebooks/handson_analysis.ipynb
@@ -42,6 +42,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from nilearn import plotting\n",
+    "%matplotlib inline\n",
+    "\n",
     "# Get the Node and Workflow object\n",
     "from nipype import Node, Workflow\n",
     "\n",

--- a/notebooks/handson_preprocessing.ipynb
+++ b/notebooks/handson_preprocessing.ipynb
@@ -70,6 +70,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from nilearn import plotting\n",
+    "%matplotlib inline\n",
+    "\n",
     "# Get the Node and Workflow object\n",
     "from nipype import Node, Workflow\n",
     "\n",


### PR DESCRIPTION
Doing `from nilearn import plotting` after `%matplotlib inline` creates a long list of warnings.

By inverting the order those warnings don't appear.