### PR TITLE
reduction of n_procs=8 to n_procs=4

### DIFF
--- a/notebooks/example_1stlevel.ipynb
+++ b/notebooks/example_1stlevel.ipynb
@@ -394,7 +394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "l1analysis.run('MultiProc', plugin_args={'n_procs': 8})"
+    "l1analysis.run('MultiProc', plugin_args={'n_procs': 4})"
    ]
   },
   {

--- a/notebooks/example_normalize.ipynb
+++ b/notebooks/example_normalize.ipynb
@@ -288,7 +288,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "antsflow.run('MultiProc', plugin_args={'n_procs': 8})"
+    "antsflow.run('MultiProc', plugin_args={'n_procs': 4})"
    ]
   },
   {
@@ -494,7 +494,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spmflow.run('MultiProc', plugin_args={'n_procs': 8})"
+    "spmflow.run('MultiProc', plugin_args={'n_procs': 4})"
    ]
   },
   {

--- a/notebooks/example_preprocessing.ipynb
+++ b/notebooks/example_preprocessing.ipynb
@@ -403,7 +403,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "preproc.run('MultiProc', plugin_args={'n_procs': 8})"
+    "preproc.run('MultiProc', plugin_args={'n_procs': 4})"
    ]
   },
   {

--- a/notebooks/handson_analysis.ipynb
+++ b/notebooks/handson_analysis.ipynb
@@ -854,7 +854,7 @@
    },
    "outputs": [],
    "source": [
-    "analysis1st.run('MultiProc', plugin_args={'n_procs': 8})"
+    "analysis1st.run('MultiProc', plugin_args={'n_procs': 4})"
    ]
   },
   {
@@ -1551,7 +1551,7 @@
    },
    "outputs": [],
    "source": [
-    "analysis2nd.run('MultiProc', plugin_args={'n_procs': 8})"
+    "analysis2nd.run('MultiProc', plugin_args={'n_procs': 4})"
    ]
   },
   {

--- a/notebooks/handson_preprocessing.ipynb
+++ b/notebooks/handson_preprocessing.ipynb
@@ -1208,7 +1208,7 @@
    },
    "outputs": [],
    "source": [
-    "preproc.run('MultiProc', plugin_args={'n_procs': 8})"
+    "preproc.run('MultiProc', plugin_args={'n_procs': 4})"
    ]
   },
   {
@@ -1587,7 +1587,7 @@
    },
    "outputs": [],
    "source": [
-    "preproc.run('MultiProc', plugin_args={'n_procs': 8})"
+    "preproc.run('MultiProc', plugin_args={'n_procs': 4})"
    ]
   },
   {
@@ -1658,7 +1658,7 @@
    "outputs": [],
    "source": [
     "# Runs the preprocessing workflow again, this time with substitutions\n",
-    "preproc.run('MultiProc', plugin_args={'n_procs': 8})"
+    "preproc.run('MultiProc', plugin_args={'n_procs': 4})"
    ]
   },
   {
@@ -1738,7 +1738,7 @@
    "outputs": [],
    "source": [
     "# Runs the preprocessing workflow again, this time with substitutions\n",
-    "preproc.run('MultiProc', plugin_args={'n_procs': 8})"
+    "preproc.run('MultiProc', plugin_args={'n_procs': 4})"
    ]
   },
   {

--- a/notebooks/wip_resource_sched_profiler.ipynb
+++ b/notebooks/wip_resource_sched_profiler.ipynb
@@ -47,7 +47,7 @@
     "The ``MultiProc`` workflow plugin schedules node execution based on the resources used by the current running nodes and the total resources available to the workflow. The plugin utilizes the plugin arguments ``n_procs`` and ``memory_gb`` to set the maximum resources a workflow can utilize. To limit a workflow to using 8 cores and 10 GB of RAM:\n",
     "\n",
     "```python\n",
-    "args_dict = {'n_procs' : 8, 'memory_gb' : 10}\n",
+    "args_dict = {'n_procs': 8, 'memory_gb': 10}\n",
     "workflow.run(plugin='MultiProc', plugin_args=args_dict)\n",
     "```\n",
     "\n",
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "from nipype.utils.profiler import log_nodes_cb\n",
-    "args_dict = {'n_procs' : 8, 'memory_gb' : 10, 'status_callback' : log_nodes_cb}"
+    "args_dict = {'n_procs': 8, 'memory_gb': 10, 'status_callback': log_nodes_cb}"
    ]
   },
   {
@@ -191,7 +191,7 @@
    "outputs": [],
    "source": [
     "from nipype.utils.profiler import log_nodes_cb\n",
-    "args_dict = {'n_procs' : 8, 'memory_gb' : 10, 'status_callback' : log_nodes_cb}\n",
+    "args_dict = {'n_procs': 8, 'memory_gb': 10, 'status_callback': log_nodes_cb}\n",
     "workflow.run(plugin='MultiProc', plugin_args=args_dict)\n",
     "\n",
     "# ...workflow finishes and writes callback log to '/home/user/run_stats.log'\n",


### PR DESCRIPTION
As discussed in https://github.com/miykael/nipype_tutorial/issues/104, this PR reduces the number of parallel threads to 4 in the examples and handson, to prevent processing overload.