### PR TITLE
FIX: replaces orthoview with plot_anat

### DIFF
--- a/notebooks/advanced_create_interfaces.ipynb
+++ b/notebooks/advanced_create_interfaces.ipynb
@@ -76,9 +76,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import nibabel as nb\n",
-    "%matplotlib inline\n",
-    "nb.load('/data/ds000114/sub-01/ses-test/anat/sub-01_ses-test_T1w.nii.gz').orthoview();"
+    "from nilearn.plotting import plot_anat\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_anat('/data/ds000114/sub-01/ses-test/anat/sub-01_ses-test_T1w.nii.gz', dim=-1);"
    ]
   },
   {
@@ -123,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nb.load('/data/ds000114/sub-01/ses-test/anat/sub-01_ses-test_T1w_bet.nii.gz').orthoview();"
+    "plot_anat('/data/ds000114/sub-01/ses-test/anat/sub-01_ses-test_T1w_bet.nii.gz', dim=-1);"
    ]
   },
   {
@@ -162,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nb.load(res.outputs.out_file).orthoview();"
+    "plot_anat(res.outputs.out_file, dim=-1);"
    ]
   },
   {
@@ -686,7 +694,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nb.load(result.outputs.out_file).orthoview()"
+    "plot_anat(result.outputs.out_file, dim=-1);"
    ]
   },
   {
@@ -765,7 +773,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nb.load(orig_image).orthoview()"
+    "plot_anat(orig_image, dim=-1);"
    ]
   },
   {
@@ -774,7 +782,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nb.load('translated.nii.gz').orthoview()"
+    "plot_anat('translated.nii.gz', dim=-1);"
    ]
   },
   {
@@ -857,7 +865,7 @@
    "outputs": [],
    "source": [
     "# Plot the result\n",
-    "nb.load('translated_functioninterface.nii.gz').orthoview()"
+    "plot_anat('translated_functioninterface.nii.gz', dim=-1);"
    ]
   },
   {
@@ -1096,7 +1104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nb.load(result.outputs.out_file).orthoview()"
+    "plot_anat(result.outputs.out_file, dim=-1);"
    ]
   },
   {

--- a/notebooks/handson_analysis.ipynb
+++ b/notebooks/handson_analysis.ipynb
@@ -1329,9 +1329,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import nibabel as nb\n",
-    "mask = nb.load('/output/datasink_handson/GM_mask.nii')\n",
-    "mask.orthoview()"
+    "from nilearn.plotting import plot_anat\n",
+    "%matplotlib inline\n",
+    "plot_anat('/output/datasink_handson/GM_mask.nii', dim=-1)"
    ]
   },
   {


### PR DESCRIPTION
Closes https://github.com/miykael/nipype_tutorial/issues/82.

Small PR that replaces `nibabel`'s `orthoview` with `nilearn`'s `plot_anat`.