### PR TITLE
[WIP] Update tutorial to use BIDSDataGrabber

### DIFF
--- a/notebooks/basic_data_input_bids.ipynb
+++ b/notebooks/basic_data_input_bids.ipynb
@@ -212,9 +212,14 @@
     "from nipype.interfaces.utility import Function\n",
     "\n",
     "bg = Node(BIDSDataGrabber(), name='bids-grabber')\n",
-    "bg.inputs.base_dir = '/data/ds000114'\n",
-    "bg.inputs.subject = '01'\n",
-    "bg.inputs.output_query = {'bolds': dict(type='bold')}"
+    "bg.inputs.base_dir = '/data/ds000114'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can define static filters, that will apply to all queries, by modifying the appropriate input"
    ]
   },
   {
@@ -223,6 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "bg.inputs.subject = '01'\n",
     "res = bg.run()\n",
     "res.outputs"
    ]
@@ -231,7 +237,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Works like a charm! Lets put it in a workflow. We are not going to analyze any data, but for demonstration purposes, we will add a couple of nodes that pretend to analyze their inputs"
+    "Note that by default `BIDSDataGrabber` will fetch `nifti` files matching modality `func` and `anat`, and output them as two output fields. \n",
+    "\n",
+    "To define custom fields, simply define the arguments to pass to `BIDSLayout.get` as dictionary, like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bg.inputs.output_query = {'bolds': dict(type='bold')}\n",
+    "res = bg.run()\n",
+    "res.outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This results in a single output field `bold`, which returns all files with `type:bold` for `subject:\"01\"` \n",
+    "\n",
+    "Now, lets put it in a workflow. We are not going to analyze any data, but for demonstration purposes, we will add a couple of nodes that pretend to analyze their inputs"
    ]
   },
   {
@@ -289,7 +317,7 @@
     "from nipype.pipeline import Node, MapNode, Workflow\n",
     "from nipype.interfaces.io import BIDSDataGrabber\n",
     "\n",
-    "ex2_BIDSDataGrabber = BIDSDataGrabber(outfields = ['T1w'])\n",
+    "ex2_BIDSDataGrabber = BIDSDataGrabber()\n",
     "ex2_BIDSDataGrabber.inputs.base_dir = '/data/ds000114'\n",
     "ex2_BIDSDataGrabber.inputs.subject = '10'\n",
     "ex2_BIDSDataGrabber.inputs.output_query = {'T1w': dict(modality='anat')}\n",
@@ -303,7 +331,7 @@
    "metadata": {},
    "source": [
     "## Iterating over subject labels\n",
-    "In the previous example, we demonstrated how to use `pybids` to \"analyze\" one subject. How can we scale it for all subjects? Easy - using `iterables` (more in [Iteration/Iterables](basic_iteration.ipynb)."
+    "In the previous example, we demonstrated how to use `pybids` to \"analyze\" one subject. How can we scale it for all subjects? Easy - using `iterables` (more in [Iteration/Iterables](basic_iteration.ipynb))."
    ]
   },
   {
@@ -342,7 +370,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Can we incorporate this into our pipeline? Yes, we can!\n",
+    "Can we incorporate this into our pipeline? Yes, we can! To do so, let's use a `Function` node to use `BIDSLayout` in a custom way.\n",
     "(More about MapNode in [MapNode](basic_mapnodes.ipynb))"
    ]
   },

--- a/notebooks/basic_data_input_bids.ipynb
+++ b/notebooks/basic_data_input_bids.ipynb
@@ -2,7 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Data input for BIDS datasets\n",
     "`DataGrabber` and `SelectFiles` are great if you are dealing with generic datasets with arbitrary organization. However, if you have decided to use Brain Imaging Data Structure (BIDS) to organize your data (or got your hands on a BIDS dataset) you can take advantage of a formal structure BIDS imposes. In this short tutorial, you will learn how to do this."
@@ -10,7 +13,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## `pybids` - a Python API for working with BIDS datasets\n",
     "`pybids` is a lightweight python API for querying BIDS folder structure for specific files and metadata. You can install it from PyPi:\n",
@@ -22,7 +28,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## The `layout` object and simple queries\n",
     "To begin working with pybids we need to initialize a layout object. We will need it to do all of our queries"
@@ -31,7 +40,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "from bids.layout import BIDSLayout\n",
@@ -41,7 +54,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "!tree -L 4 /data/ds000114/"
@@ -49,7 +66,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Let's figure out what are the subject labels in this dataset"
    ]
@@ -57,7 +77,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "layout.get_subjects()"
@@ -65,7 +89,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "What modalities are included in this dataset?"
    ]
@@ -73,7 +100,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "layout.get_modalities()"
@@ -81,7 +112,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Which different data types are included in this dataset?"
    ]
@@ -89,7 +123,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "layout.get_types(modality='func')"
@@ -97,7 +135,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "What are the different tasks included in this dataset?"
    ]
@@ -105,7 +146,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "layout.get_tasks()"
@@ -113,7 +158,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "We can also ask for all of the data for a particular subject and one modality."
    ]
@@ -121,7 +169,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "layout.get(subject='01', modality=\"anat\", session=\"test\")"
@@ -129,7 +181,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "We can also ask for a specific subset of data. Note that we are using extension filter to get just the imaging data (BIDS allows both .nii and .nii.gz so we need to include both)."
    ]
@@ -137,7 +192,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "layout.get(subject='01', type='bold', extensions=['nii', 'nii.gz'])"
@@ -145,7 +204,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "You probably noticed that this method does not only return the file paths, but objects with relevant query fields. We can easily extract just the file paths."
    ]
@@ -153,7 +215,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "layout.get(subject='01', type='bold', extensions=['nii', 'nii.gz'], return_type='file')"
@@ -161,7 +227,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Exercise 1:\n",
     "List all files for the \"linebisection\" task for subject 02."
@@ -171,6 +240,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "solution2": "shown",
     "solution2_first": true
    },
@@ -183,6 +255,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "solution2": "shown"
    },
    "outputs": [],
@@ -195,16 +270,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
-    "## Including `pybids` in your `nipype` workflow\n",
-    "This is great, but what we really want is to include this into our nipype workflows. To do this, we can import the BIDSDataGrabber Interface, which wraps around pybids."
+    "## `BIDSDataGrabber`: Including `pybids` in your `nipype` workflow\n",
+    "This is great, but what we really want is to include this into our nipype workflows. To do this, we can import `BIDSDataGrabber`, which provides an `Interface` for `BIDSLayout.get`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "from nipype.interfaces.io import BIDSDataGrabber\n",
@@ -217,7 +299,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "You can define static filters, that will apply to all queries, by modifying the appropriate input"
    ]
@@ -225,7 +310,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "bg.inputs.subject = '01'\n",
@@ -235,7 +324,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Note that by default `BIDSDataGrabber` will fetch `nifti` files matching modality `func` and `anat`, and output them as two output fields. \n",
     "\n",
@@ -245,7 +337,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "bg.inputs.output_query = {'bolds': dict(type='bold')}\n",
@@ -255,7 +351,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "This results in a single output field `bold`, which returns all files with `type:bold` for `subject:\"01\"` \n",
     "\n",
@@ -265,7 +364,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "def printMe(paths):\n",
@@ -278,7 +381,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "wf = Workflow(name=\"bids_demo\")\n",
@@ -288,7 +395,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Exercise 2:\n",
     "Modify the `BIDSDataGrabber` and the workflow to collect T1ws images for subject `10`."
@@ -298,6 +408,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "solution2": "shown",
     "solution2_first": true
    },
@@ -310,6 +423,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "solution2": "shown"
    },
    "outputs": [],
@@ -328,7 +444,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Iterating over subject labels\n",
     "In the previous example, we demonstrated how to use `pybids` to \"analyze\" one subject. How can we scale it for all subjects? Easy - using `iterables` (more in [Iteration/Iterables](basic_iteration.ipynb))."
@@ -337,7 +456,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "bg_all = Node(BIDSDataGrabber(), name='bids-grabber')\n",
@@ -351,7 +474,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Accessing additional metadata\n",
     "Querying different files is nice, but sometimes you want to access more metadata. For example `RepetitionTime`. `pybids` can help with that as well"
@@ -360,7 +486,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "layout.get_metadata('/data/ds000114/sub-01/ses-test/func/sub-01_ses-test_task-fingerfootlips_bold.nii.gz')"
@@ -368,7 +498,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Can we incorporate this into our pipeline? Yes, we can! To do so, let's use a `Function` node to use `BIDSLayout` in a custom way.\n",
     "(More about MapNode in [MapNode](basic_mapnodes.ipynb))"
@@ -377,7 +510,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "def printMetadata(path, data_dir):\n",
@@ -394,6 +531,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -405,7 +545,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Exercise 3:\n",
     "Modify the `printMetadata` function to also print `EchoTime` "
@@ -415,6 +558,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "solution2": "shown",
     "solution2_first": true
    },
@@ -427,6 +573,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "solution2": "shown"
    },
    "outputs": [],
@@ -444,6 +593,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "solution2": "shown"
    },
    "outputs": [],
@@ -471,7 +623,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -485,7 +637,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/basic_data_input_bids.ipynb
+++ b/notebooks/basic_data_input_bids.ipynb
@@ -623,7 +623,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -637,7 +637,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/basic_data_input_bids.ipynb
+++ b/notebooks/basic_data_input_bids.ipynb
@@ -171,7 +171,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "solution2": "hidden",
+    "solution2": "shown",
     "solution2_first": true
    },
    "outputs": [],
@@ -183,7 +183,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "solution2": "hidden"
+    "solution2": "shown"
    },
    "outputs": [],
    "source": [
@@ -198,7 +198,7 @@
    "metadata": {},
    "source": [
     "## Including `pybids` in your `nipype` workflow\n",
-    "This is great, but what we really want is to include this into our `nipype` workflows. How to do this? We can create our own custom `BIDSDataGrabber` using a `Function` Interface. First, we need a plain Python function that for a given subject label and dataset location will return a list of BOLD files."
+    "This is great, but what we really want is to include this into our nipype workflows. To do this, we can import the BIDSDataGrabber Interface, which wraps around pybids."
    ]
   },
   {
@@ -207,41 +207,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_niftis(subject_id, data_dir):\n",
-    "    # Remember that all the necessary imports need to be INSIDE the function for the Function Interface to work!\n",
-    "    from bids.layout import BIDSLayout\n",
-    "    \n",
-    "    layout = BIDSLayout(data_dir)\n",
-    "    \n",
-    "    bolds = layout.get(subject=subject_id, type=\"bold\", return_type='file', extensions=['nii', 'nii.gz'])\n",
-    "    \n",
-    "    return bolds"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "get_niftis('01', '/data/ds000114')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Ok we got our function. Now we need to wrap it inside a Node object."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "from nipype.interfaces.io import BIDSDataGrabber\n",
     "from nipype.pipeline import Node, MapNode, Workflow\n",
-    "from nipype.interfaces.utility import IdentityInterface, Function"
+    "from nipype.interfaces.utility import Function\n",
+    "\n",
+    "bg = Node(BIDSDataGrabber(), name='bids-grabber')\n",
+    "bg.inputs.base_dir = '/data/ds000114'\n",
+    "bg.inputs.subject = '01'\n",
+    "bg.inputs.output_query = {'bolds': dict(type='bold')}"
    ]
   },
   {
@@ -250,20 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "BIDSDataGrabber = Node(Function(function=get_niftis, input_names=[\"subject_id\",\n",
-    "                                       \"data_dir\"],\n",
-    "                                   output_names=[\"bolds\"]), name=\"BIDSDataGrabber\")\n",
-    "BIDSDataGrabber.inputs.data_dir = \"/data/ds000114\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "BIDSDataGrabber.inputs.subject_id='01'\n",
-    "res = BIDSDataGrabber.run()\n",
+    "res = bg.run()\n",
     "res.outputs"
    ]
   },
@@ -271,7 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Works like a charm! (hopefully :) Lets put it in a workflow. We are not going to analyze any data, but for demonstration purposes, we will add a couple of nodes that pretend to analyze their inputs"
+    "Works like a charm! Lets put it in a workflow. We are not going to analyze any data, but for demonstration purposes, we will add a couple of nodes that pretend to analyze their inputs"
    ]
   },
   {
@@ -294,7 +254,7 @@
    "outputs": [],
    "source": [
     "wf = Workflow(name=\"bids_demo\")\n",
-    "wf.connect(BIDSDataGrabber, \"bolds\", analyzeBOLD, \"paths\")\n",
+    "wf.connect(bg, \"bolds\", analyzeBOLD, \"paths\")\n",
     "wf.run()"
    ]
   },
@@ -310,7 +270,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "solution2": "hidden",
+    "solution2": "shown",
     "solution2_first": true
    },
    "outputs": [],
@@ -322,29 +282,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "solution2": "hidden"
+    "solution2": "shown"
    },
    "outputs": [],
    "source": [
     "from nipype.pipeline import Node, MapNode, Workflow\n",
-    "from nipype.interfaces.utility import IdentityInterface, Function\n",
+    "from nipype.interfaces.io import BIDSDataGrabber\n",
     "\n",
-    "def get_T1w(subject_id, data_dir):\n",
-    "    from bids.layout import BIDSLayout\n",
-    "    \n",
-    "    layout = BIDSLayout(data_dir)\n",
-    "    \n",
-    "    T1w = layout.get(subject=subject_id, modality=\"anat\", return_type='file')\n",
-    "    \n",
-    "    return T1w\n",
+    "ex2_BIDSDataGrabber = BIDSDataGrabber(outfields = ['T1w'])\n",
+    "ex2_BIDSDataGrabber.inputs.base_dir = '/data/ds000114'\n",
+    "ex2_BIDSDataGrabber.inputs.subject = '10'\n",
+    "ex2_BIDSDataGrabber.inputs.output_query = {'T1w': dict(modality='anat')}\n",
     "\n",
-    "ex2_BIDSDataGrabber = Node(Function(function=get_T1w, \n",
-    "                                    input_names=[\"subject_id\", \"data_dir\"],\n",
-    "                                       output_names=[\"T1w\"]), \n",
-    "                           name=\"ex2\")\n",
-    "ex2_BIDSDataGrabber.inputs.data_dir = \"/data/ds000114\"\n",
-    "\n",
-    "ex2_BIDSDataGrabber.inputs.subject_id='10'\n",
     "ex2_res = ex2_BIDSDataGrabber.run()\n",
     "ex2_res.outputs"
    ]
@@ -363,7 +312,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "BIDSDataGrabber.iterables = ('subject_id', layout.get_subjects()[:2])\n",
+    "bg_all = Node(BIDSDataGrabber(), name='bids-grabber')\n",
+    "bg_all.inputs.base_dir = '/data/ds000114'\n",
+    "bg_all.inputs.output_query = {'bolds': dict(type='bold')}\n",
+    "bg_all.iterables = ('subject', layout.get_subjects()[:2])\n",
+    "wf = Workflow(name=\"bids_demo\")\n",
+    "wf.connect(bg_all, \"bolds\", analyzeBOLD, \"paths\")\n",
     "wf.run()"
    ]
   },
@@ -411,11 +365,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "wf = Workflow(name=\"bids_demo\")\n",
-    "wf.connect(BIDSDataGrabber, \"bolds\", analyzeBOLD2, \"path\")\n",
+    "wf.connect(bg, \"bolds\", analyzeBOLD2, \"path\")\n",
     "wf.run()"
    ]
   },
@@ -431,7 +387,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "solution2": "hidden",
+    "solution2": "shown",
     "solution2_first": true
    },
    "outputs": [],
@@ -443,39 +399,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "solution2": "hidden"
+    "solution2": "shown"
    },
    "outputs": [],
    "source": [
     "from nipype.pipeline import Node, MapNode, Workflow\n",
-    "from nipype.interfaces.utility import IdentityInterface, Function\n",
+    "from nipype.interfaces.io import BIDSDataGrabber\n",
     "\n",
-    "# let's start from BidsDataGrabber again\n",
-    "def get_niftis(subject_id, data_dir):\n",
-    "    # Remember that all the necesary imports need to be INSIDE the function \n",
-    "    # for the Function Interface to work!\n",
-    "    from bids.layout import BIDSLayout\n",
-    "    \n",
-    "    layout = BIDSLayout(data_dir)\n",
-    "    \n",
-    "    bolds = layout.get(subject=subject_id, type=\"bold\", return_type='file', extensions=['nii', 'nii.gz'])\n",
-    "    \n",
-    "    return bolds\n",
-    "\n",
-    "\n",
-    "ex3_BIDSDataGrabber = Node(Function(function=get_niftis, \n",
-    "                                    input_names=[\"subject_id\", \"data_dir\"],\n",
-    "                                    output_names=[\"bolds\"]), \n",
-    "                           name=\"ex3_BIDSDataGrabber\")\n",
-    "ex3_BIDSDataGrabber.inputs.data_dir = \"/data/ds000114\"\n",
-    "ex3_BIDSDataGrabber.inputs.subject_id='01'"
+    "ex3_BIDSDataGrabber = Node(BIDSDataGrabber(), name='bids-grabber')\n",
+    "ex3_BIDSDataGrabber.inputs.base_dir = '/data/ds000114'\n",
+    "ex3_BIDSDataGrabber.inputs.subject = '01'\n",
+    "ex3_BIDSDataGrabber.inputs.output_query = {'bolds': dict(type='bold')}"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "solution2": "hidden"
+    "solution2": "shown"
    },
    "outputs": [],
    "source": [
@@ -516,7 +457,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I've gone through and updated `basic_data_input_bids` to use niype's `BIDSDataGrabber` interface. Check it out and let me know if it makes sense to you.

There are a few more changes to make (not all of which may make into this PR)
- [x] Expand tutorial a bit. There are a few more useful features of `BIDSDataGrabber` I may want to highlight. E.g. the defaults are quite usefunc (`func` & `anat` by default), and more complex queries are possible.
- [ ] Fix outdated BIDS entities. E.g. `modality` is no longer a supported entity. It was a mistake to include it and according to `BIDS` spec its actually `datatype`
- [ ] Maybe wait for updated to `BIDSDataGrabber` (for same reason as above, and to support derivatives, and new pybids syntax in 0.7)

Also, you're example of loading meta-data makes it obvious it would be quite useful if an interface made that easier (rather than having to wrap in a `Function`)