### PR TITLE
FIX: Datalad command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,7 @@ RUN export PATH="/opt/miniconda-latest/bin:$PATH" \
     &&   pip install --no-cache-dir  \
              https://github.com/nipy/nipype/tarball/master \
              https://github.com/INCF/pybids/tarball/0.7.1 \
+             niflow-nipype1-workflows \
              nilearn \
              datalad[full] \
              nipy \

--- a/notebooks/basic_data_input.ipynb
+++ b/notebooks/basic_data_input.ipynb
@@ -651,7 +651,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!datalad get -r -J 4 /data/ds000114/derivatives/freesurfer/sub-01"
+    "!datalad get -r -J 4 -d /data/ds000114 /data/ds000114/derivatives/freesurfer/sub-01"
    ]
   },
   {

--- a/notebooks/example_normalize.ipynb
+++ b/notebooks/example_normalize.ipynb
@@ -27,7 +27,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "datalad get -J 4 /data/ds000114/derivatives/fmriprep/sub-0[2345789]/anat/*h5"
+    "datalad get -J 4 -d /data/ds000114 /data/ds000114/derivatives/fmriprep/sub-0[2345789]/anat/*h5"
    ]
   },
   {

--- a/notebooks/example_preprocessing.ipynb
+++ b/notebooks/example_preprocessing.ipynb
@@ -32,8 +32,9 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "datalad get -J 4 /data/ds000114/derivatives/fmriprep/sub-*/anat/*preproc.nii.gz \\\n",
-    "                /data/ds000114/sub-*/ses-test/func/*fingerfootlips*"
+    "datalad get -J 4 -d /data/ds000114 \\\n",
+    "    /data/ds000114/derivatives/fmriprep/sub-*/anat/*preproc.nii.gz \\\n",
+    "    /data/ds000114/sub-*/ses-test/func/*fingerfootlips*"
    ]
   },
   {

--- a/notebooks/handson_preprocessing.ipynb
+++ b/notebooks/handson_preprocessing.ipynb
@@ -29,8 +29,9 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "datalad get -J 4 /data/ds000114/sub-0[234789]/ses-test/anat/sub-0[234789]_ses-test_T1w.nii.gz \\\n",
-    "                /data/ds000114/sub-0[234789]/ses-test/func/*fingerfootlips*"
+    "datalad get -J 4 -d /data/ds000114 \\\n",
+    "    /data/ds000114/sub-0[234789]/ses-test/anat/sub-0[234789]_ses-test_T1w.nii.gz \\\n",
+    "    /data/ds000114/sub-0[234789]/ses-test/func/*fingerfootlips*"
    ]
   },
   {

--- a/notebooks/introduction_dataset.ipynb
+++ b/notebooks/introduction_dataset.ipynb
@@ -68,9 +68,9 @@
    "source": [
     "%%bash\n",
     "cd /data/ds000114\n",
-    "datalad get -J 4 /data/ds000114/derivatives/fmriprep/sub-*/anat/*preproc.nii.gz \\\n",
-    "                /data/ds000114/sub-01/ses-test/anat \\\n",
-    "                /data/ds000114/sub-*/ses-test/func/*fingerfootlips*"
+    "datalad get -J 4 derivatives/fmriprep/sub-*/anat/*preproc.nii.gz \\\n",
+    "                 sub-01/ses-test/anat \\\n",
+    "                 sub-*/ses-test/func/*fingerfootlips*"
    ]
   },
   {
@@ -121,7 +121,7 @@
    "source": [
     "%%bash\n",
     "cd /data/ds000114\n",
-    "datalad get /data/ds000114/sub-01/ses-test/func/sub-01_ses-test_task-linebisection_events.tsv"
+    "datalad get sub-01/ses-test/func/sub-01_ses-test_task-linebisection_events.tsv"
    ]
   },
   {


### PR DESCRIPTION
Tests are currently failing due to datalad 0.12's release. Explicitly specifying the dataset with `-d` resolves the issue.