### PR TITLE
ENH: Allow GH Action to run with manual trigger

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,6 +5,12 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      nipype_branch:
+        description: 'Build specific Nipype branch'
+        required: true
+        default: 'master'
 
 
 jobs:
@@ -14,7 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: generate the Dockerfile from generate.sh
-      run: bash generate.sh
+      run: |
+        BRANCH=${{ github.event.inputs.nipype_branch }}
+        BRANCH=${BRANCH:-"master"}
+        bash generate.sh $BRANCH
     # In this step, this action saves a list of existing images,
     # the cache is created without them in the post run.
     # It also restores the cache if it exists.

--- a/generate.sh
+++ b/generate.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+NIPYPE_BRANCH=${1:-"master"}
+case $NIPYPE_BRANCH in
+  master)
+    NIPYPE_URL="https://github.com/nipy/nipype/tarball/master"
+  ;;
+  *)
+    NIPYPE_URL="git+https://github.com/nipy/nipype.git@${NIPYPE_BRANCH}"
+  ;;
+esac
+
 # Generate Dockerfile
 generate_docker() {
   docker run --rm kaczmarj/neurodocker:master generate docker \
@@ -17,7 +27,7 @@ generate_docker() {
            --miniconda \
              conda_install="python=3.8 pytest jupyter jupyterlab jupyter_contrib_nbextensions
                             traits pandas matplotlib scikit-learn scikit-image seaborn nbformat nb_conda" \
-             pip_install="https://github.com/nipy/nipype/tarball/master
+             pip_install="$NIPYPE_URL
                           pybids==0.13.1
                           nilearn datalad[full] nipy duecredit nbval niflow-nipype1-workflows" \
              create_env="neuro" \
@@ -56,7 +66,7 @@ generate_singularity() {
            --miniconda \
              conda_install="python=3.7 pytest jupyter jupyterlab jupyter_contrib_nbextensions
                             traits pandas matplotlib scikit-learn scikit-image seaborn nbformat nb_conda" \
-             pip_install="https://github.com/nipy/nipype/tarball/master
+             pip_install="$NIPYPE_URL
                           pybids==0.13.1
                           nilearn datalad[full] nipy duecredit nbval niflow-nipype1-workflows" \
              create_env="neuro" \

--- a/generate.sh
+++ b/generate.sh
@@ -64,7 +64,7 @@ generate_singularity() {
            --user=neuro \
            --workdir /home/neuro \
            --miniconda \
-             conda_install="python=3.7 pytest jupyter jupyterlab jupyter_contrib_nbextensions
+             conda_install="python=3.8 pytest jupyter jupyterlab jupyter_contrib_nbextensions
                             traits pandas matplotlib scikit-learn scikit-image seaborn nbformat nb_conda" \
              pip_install="$NIPYPE_URL
                           pybids==0.13.1


### PR DESCRIPTION
- Expands `generate.sh` to allow building from any nipype branch.
- Bumps singularity build's python to 3.8 to mirror the docker build.